### PR TITLE
Readme mermaid diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Test schemas against the generated validators (JS and WASM) directly in your bro
 
 ```mermaid
 flowchart TD
-    A["JTD schema (JSON)"] --> B["jtd-codegen (Rust)"]
-    B --> |emit_js| C["JavaScript ESM2020 module"]
-    B --> |emit_rs| D["Rust source file"]
-    D --> E["cargo / wasm-pack"]
-    E --> F[".wasm binary"]
+    A[JTD schema JSON] --> B[jtd-codegen Rust]
+    B --> |emit_js| C[JavaScript ESM2020 module]
+    B --> |emit_rs| D[Rust source file]
+    D --> E[cargo + wasm-pack]
+    E --> F[wasm binary]
 ```
 
 ## ✨ Features


### PR DESCRIPTION
Simplify Mermaid diagram syntax in README to ensure proper rendering on GitHub.

The previous Mermaid syntax, particularly with quotes, parentheses, and slashes in node labels, caused rendering issues on GitHub's Mermaid parser. This change uses a more basic syntax for improved compatibility and reliable rendering.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9e012cb9-cd71-47be-a809-2803b21e06a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e012cb9-cd71-47be-a809-2803b21e06a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

